### PR TITLE
Badges

### DIFF
--- a/deploy
+++ b/deploy
@@ -23,7 +23,8 @@ prefix = root['prefix'] + label
 # Check that we're doing the right thing.
 s3_path = f"{root['bucket']}/{prefix}"
 
-print(f"The following files will be pushed to 's3://{s3_path}':")
+print(f"The following files will be pushed to 's3://{s3_path}' "
+      f"(they will be PUBLIC):")
 for fname in os.listdir('dist'):
     print('\t', os.path.join('dist', fname))
 res = input("Continue (Y/n)?")
@@ -39,4 +40,4 @@ for fname in os.listdir('dist'):
     fpath = os.path.join('dist', fname)
     print(f"Putting {fpath} -> s3://{s3_path}/{fname}")
     s3.upload_file(os.path.join('dist', fname), root['bucket'],
-                   f'{prefix}/{fname}')
+                   f'{prefix}/{fname}', ExtraArgs={'ACL': 'public-read'})

--- a/deploy
+++ b/deploy
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import boto3
+
+# Check the version is Python 3.6+
+assert sys.version_info.major >= 3 and sys.version_info.minor >= 6, \
+    "Python 3.6+ required."
+
+# Get the deployment label.
+if len(sys.argv) != 2:
+    raise ValueError(f"Wrong number of arguments ({len(sys.argv)}): {sys.argv}")
+label = sys.argv[-1]
+
+# Load the config file for the s3 bucket and prefix.
+with open('deployment_config.json', 'r') as f:
+    conf = json.load(f)
+root = conf['root']
+prefix = root['prefix'] + label
+
+# Check that we're doing the right thing.
+s3_path = f"{root['bucket']}/{prefix}"
+
+print(f"The following files will be pushed to 's3://{s3_path}':")
+for fname in os.listdir('dist'):
+    print('\t', os.path.join('dist', fname))
+res = input("Continue (Y/n)?")
+
+if res.lower() != 'y' and res != '':
+    print("Aborting.")
+    sys.exit()
+
+# Push the files.
+s3 = boto3.client('s3')
+
+for fname in os.listdir('dist'):
+    fpath = os.path.join('dist', fname)
+    print(f"Putting {fpath} -> s3://{s3_path}/{fname}")
+    s3.upload_file(os.path.join('dist', fname), root['bucket'],
+                   f'{prefix}/{fname}')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "vue-cli-service build --target lib --name IndralabVue src/index.js",
     "lint": "vue-cli-service lint",
     "watch": "npm run build -- --watch",
-    "test": "npm run watch -- --mode development"
+    "test": "npm run watch -- --mode development",
+    "deploy": "python deploy"
   },
   "dependencies": {
     "core-js": "^3.4.4",

--- a/src/components/Evidence/Evidence.vue
+++ b/src/components/Evidence/Evidence.vue
@@ -5,7 +5,7 @@
       <div class='col-1'>
         <div class='row'>
           <div class='col-3 nvm clickable text-center'
-               :class="{ 'has-curation-badge': num_curations > 0 }"
+               :class="`${this.curation_badge}`"
                v-on:click='toggleCuration'
                :title='num_curations'
                :style="`color: ${this.icon_color};`">
@@ -39,6 +39,14 @@
       source_api: String,
       text_refs: Object,
       num_curations: Number,
+      num_correct: {
+        type: Number,
+        default: null
+      },
+      num_incorrect: {
+        type: Number,
+        default: null
+      },
       source_hash: String,
       stmt_hash: String
     },
@@ -74,6 +82,18 @@
           default:
             return '#000000'
         }
+      },
+
+      curation_badge: function() {
+        if (this.num_correct > 0) {
+          return 'has-curation-badge';
+        } else if (this.num_incorrect > 0) {
+          return 'has-incorrect-curation-badge';
+        } else if (this.num_curations > 0) {
+          return 'has-curation-badge';
+        } else {
+          return '';
+        }
       }
     }
   }
@@ -86,6 +106,11 @@
 
   .has-curation-badge {
     background-color: #d3fccf;
+    border-radius: 1em;
+  }
+
+  .has-incorrect-curation-badge {
+    background-color: #ffcccc;
     border-radius: 1em;
   }
 

--- a/src/components/Statement/Statement.vue
+++ b/src/components/Statement/Statement.vue
@@ -163,10 +163,10 @@
         let ret = '';
         if ( !this.show_total_ev_only ) {
           let n = 0;
-          if (this.evidence != null)
-            n += this.evidence.length;
           if (this.loaded_evidence != null)
             n += this.loaded_evidence.length;
+          else if (this.evidence != null)
+            n += this.evidence.length;
           ret += n;
         } else {
           ret += 0;

--- a/src/components/Statement/Statement.vue
+++ b/src/components/Statement/Statement.vue
@@ -78,7 +78,8 @@
       url: {
         type: String,
         default: null
-      }
+    },
+      badges: Array
     },
     data: function() {
       return {
@@ -183,7 +184,35 @@
         if (this.url != null)
           return this.url;
         return this.$stmt_hash_url
+      },
+      displayed_badges: function() {
+        if (this.badges) {
+          let badges = []
+          for (let badge of this.badges) {
+            if (badge.label == 'evidence') {
+              badge['num'] = this.num_evidence;
+            }
+            if (badge.num) {
+              badges.push(badge)
+            }
+          }
+          return badges;
+        } else {
+          if (!this.sources) {
+            let badges = [
+              {label: 'evidence', num: this.num_evidence, color: 'grey'},
+              {label: 'curations', num: this.num_curations, symbol: '\u270E', color: '#28a745'}
+              ]
+            return badges;
+          } else {
+            let badges = [
+              {label: 'curations', num: this.num_curations, color: '#28a745'}
+              ]
+            return badges;
+          }
+        }
       }
+
     },
     mixins: [piecemeal_mixin]
   }

--- a/src/components/Statement/Statement.vue
+++ b/src/components/Statement/Statement.vue
@@ -4,13 +4,16 @@
       <div class="col text-left">
         <h4>
           <span v-html='english'></span>
-          <small v-if="!sources"
-                 class='badge badge-secondary badge-pill'>
-            {{ num_evidence }}
-          </small>
-          <small v-if='total_curations'
-                 class='badge badge-success badge-pill'>
-            &#9998; {{ total_curations }}
+          <small v-for='badge in displayed_badges'
+                :class="`badge badge-pill float-${badge.loc}`"
+                :style="`background-color: ${badge.color}; color: white;`"
+                :title="badge.title"
+                :key='badge.label'>
+              <a v-if='badge.href'
+                :style="`background-color: ${badge.color}; color: white;`"
+                :href='badge.href' target="_blank">
+                    {{ badge.symbol }}{{ badge.num }}</a>
+              <span v-else>{{ badge.symbol }}{{ badge.num }}<span>
           </small>
         </h4>
       </div>
@@ -78,7 +81,7 @@
       url: {
         type: String,
         default: null
-    },
+      },
       badges: Array
     },
     data: function() {

--- a/src/components/Statement/Statement.vue
+++ b/src/components/Statement/Statement.vue
@@ -204,12 +204,12 @@
           if (!this.sources) {
             let badges = [
               {label: 'evidence', num: this.num_evidence, color: 'grey'},
-              {label: 'curations', num: this.num_curations, symbol: '\u270E', color: '#28a745'}
+              {label: 'curations', num: this.total_curations, symbol: '\u270E', color: '#28a745'}
               ]
             return badges;
           } else {
             let badges = [
-              {label: 'curations', num: this.num_curations, color: '#28a745'}
+              {label: 'curations', num: this.total_curations, color: '#28a745'}
               ]
             return badges;
           }

--- a/src/components/Statement/Statement.vue
+++ b/src/components/Statement/Statement.vue
@@ -192,7 +192,7 @@
         if (this.badges) {
           let badges = []
           for (let badge of this.badges) {
-            if (badge.label == 'evidence') {
+            if (badge.label === 'evidence') {
               badge['num'] = this.num_evidence;
             }
             if (badge.num) {
@@ -202,16 +202,17 @@
           return badges;
         } else {
           if (!this.sources) {
-            let badges = [
+            return [
               {label: 'evidence', num: this.num_evidence, color: 'grey'},
-              {label: 'curations', num: this.total_curations, symbol: '\u270E', color: '#28a745'}
-              ]
-            return badges;
-          } else {
-            let badges = [
+              {label: 'curations', num: this.total_curations, symbol: '\u270E',
+               color: '#28a745'}
+              ];
+          } else if (this.total_curations) {
+            return [
               {label: 'curations', num: this.total_curations, color: '#28a745'}
-              ]
-            return badges;
+              ];
+          } else {
+            return [];
           }
         }
       }


### PR DESCRIPTION
This PR modifies Statement and Evidence components. 

In Statement new prop `badges` and new computed `displayed_badges` are added. Badges should be provided as an array of dictionaries specifying the attributes of the badge. If badges are not provided, default badges showing evidence count and total curations will be created.

In Evidence, in addition new props `num_correct` and `num_incorrect` were added. If provided, then curated evidences will be marked with green/red badges accordingly. If not provided, total `num_curations` will be used to mark all curations with green badge.