### PR TITLE
Collapse search box after searching the result

### DIFF
--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -16,11 +16,12 @@
                     @click="forwardButton">
               Forward &gt;
             </button>
-            <button class="btn btn-sm btn-outline-secondary"
-                type="button"
-                @click="show_search = !show_search">
-          {{ show_search ? 'Hide filters' : 'Show filters' }}
-             </button>
+            <button type="button"
+                    class="btn btn-sm"
+                    :class="show_search ? 'btn-outline-secondary' : 'btn-primary'"
+                    @click="show_search = !show_search">
+              {{ show_search ? 'Hide search box' : 'Show search box' }}
+            </button>
           </h4>
         </div>
       <div id="search-box" v-show="show_search">

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -16,9 +16,14 @@
                     @click="forwardButton">
               Forward &gt;
             </button>
+            <button class="btn btn-sm btn-outline-secondary"
+                type="button"
+                @click="show_search = !show_search">
+          {{ show_search ? 'Hide filters' : 'Show filters' }}
+             </button>
           </h4>
         </div>
-      <div id="search-box">
+      <div id="search-box" v-show="show_search">
       <div class="container pl-0">
         <form>
           <div class="form-row"
@@ -278,7 +283,10 @@
         this.agent_pairs = null;
         this.complexes_covered = null;
         this.pushHistory?.(); // harmless if you later remove history
-        return await this.search();
+
+        const search_hide = await this.search();
+        if (search_hide) this.show_search = false;
+        return search_hide;
       },
 
       search: async function() {

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -21,7 +21,7 @@
                     class="btn btn-sm"
                     :class="show_search ? 'btn-outline-secondary' : 'btn-primary'"
                     @click="show_search = !show_search">
-              {{ show_search ? 'Hide filters' : 'Show filters' }}
+              {{ show_search ? 'Hide search box' : 'Show search box' }}
             </button>
           </h4>
         </div>

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -16,11 +16,12 @@
                     @click="forwardButton">
               Forward &gt;
             </button>
-            <button type="button"
+            <button v-if="hasSearched"
+                    type="button"
                     class="btn btn-sm"
                     :class="show_search ? 'btn-outline-secondary' : 'btn-primary'"
                     @click="show_search = !show_search">
-              {{ show_search ? 'Hide search box' : 'Show search box' }}
+              {{ show_search ? 'Hide filters' : 'Show filters' }}
             </button>
           </h4>
         </div>
@@ -277,7 +278,7 @@
           alert(meshValidationError);
           return;
         }
-        
+
         this.lastSearchOk = false;
         this.shareUrl = "";
         this.next_offset = 0;
@@ -286,8 +287,16 @@
         this.pushHistory?.(); // harmless if you later remove history
 
         const search_hide = await this.search();
-        if (search_hide) this.show_search = false;
-        return search_hide;
+        if (search_hide) {
+        // wait until Vue has rendered results
+        await this.$nextTick();
+
+        // collapse and enable hide button toggle
+        this.show_search = false;
+        this.hasSearched = true;
+      }
+
+      return search_hide;
       },
 
       search: async function() {

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -18,7 +18,7 @@
             </button>
           </h4>
         </div>
-      <div id="seach-box">
+      <div id="search-box">
       <div class="container pl-0">
         <form>
           <div class="form-row"


### PR DESCRIPTION
This PR makes the search box collapse after searching the results, so that the page has more space to display the statement results.