### PR TITLE
Add grey border to different search options

### DIFF
--- a/src/components/AgentSelect/AgentSelect.vue
+++ b/src/components/AgentSelect/AgentSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group col-12 col-lg-10 mb-3">
+  <div class="col-12 col-lg-10">
     <label :for="inputId" class="d-flex align-items-center mb-2">
       {{ labelText }}
       <span

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -21,7 +21,7 @@
       <div id="seach-box">
       <div class="container pl-0">
         <form>
-          <div class="form-row"
+          <div class="form-row indra-grey-border"
               v-for="(pair, i) in hasAgentConstraints"
               :key="pair.idx">
 
@@ -47,9 +47,9 @@
         </form>
       </div>
       <div class="container pl-0">
-        <form>
+        <form class="indra-grey-border" style="padding: 10px; margin-left: -5px; margin-right: -5px;">
+          <span>Agent role</span>
           <div class="form-row">
-            <span>Agent role</span>
             <div class="role-presets">
               <button type="button"
                       class="btn-role"
@@ -104,9 +104,9 @@
       <template v-else>
         <template v-if="pair.c.class === 'HasType'">
           <div class="container pl-0">
-            <form>
+            <form class="indra-grey-border" style="padding: 10px; margin-left: -5px; margin-right: -5px;">
+              <span>Relation type:</span>
               <div class="form-row">
-                <span>Relation type:</span>
                 <type-select v-model="pair.c.constraint"></type-select>
               </div>
             </form>
@@ -116,7 +116,7 @@
         <template v-else-if="pair.c.class === 'FromMeshIds'">
           <div class="container pl-0">
             <form>
-              <div class="form-row">
+              <div class="form-row indra-grey-border">
                 <mesh-select v-model="pair.c.constraint" :example-tick="exampleTick"></mesh-select>
               </div>
             </form>
@@ -915,7 +915,7 @@
       margin-bottom: 2px;
   }
 
-  .form-row {
+  .indra-grey-border {
     margin-bottom: 15px;
     border-style: solid;
     border-color: rgba(209, 209, 209, 1);

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -916,6 +916,7 @@
   }
 
   .indra-grey-border {
+    padding: 10px;
     margin-bottom: 15px;
     border-style: solid;
     border-color: rgb(242, 242, 242);

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -918,7 +918,7 @@
   .indra-grey-border {
     margin-bottom: 15px;
     border-style: solid;
-    border-color: rgba(209, 209, 209, 1);
+    border-color: rgb(242, 242, 242);
     border-image: none;
     border-width: 2px;
     border-radius: 5px;

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -46,31 +46,37 @@
           </div>
         </form>
       </div>
-      <b>Agent role</b>
-      <div class="role-presets">
-        <button type="button"
-                class="btn-role"
-                :class="{ active: currentPreset === 'any-any' }"
-                @click.prevent="presetRoles('any-any')">
-          <img :src="roleBtn3" />
-          <span class="role-text">Subject/Object</span>
-        </button>
+      <div class="container pl-0">
+        <form>
+          <div class="form-row">
+            <span>Agent role</span>
+            <div class="role-presets">
+              <button type="button"
+                      class="btn-role"
+                      :class="{ active: currentPreset === 'any-any' }"
+                      @click.prevent="presetRoles('any-any')">
+                <img :src="roleBtn3" />
+                <span class="role-text">Subject/Object</span>
+              </button>
 
-        <button type="button"
-                class="btn-role"
-                :class="{ active: currentPreset === 's-o' }"
-                @click.prevent="presetRoles('s-o')">
-          <img :src="roleBtn2" />
-          <span class="role-text">Subject</span>
-        </button>
+              <button type="button"
+                      class="btn-role"
+                      :class="{ active: currentPreset === 's-o' }"
+                      @click.prevent="presetRoles('s-o')">
+                <img :src="roleBtn2" />
+                <span class="role-text">Subject</span>
+              </button>
 
-        <button type="button"
-                class="btn-role"
-                :class="{ active: currentPreset === 'o-s' }"
-                @click.prevent="presetRoles('o-s')">
-          <img :src="roleBtn1" />
-          <span class="role-text">Object</span>
-        </button>
+              <button type="button"
+                      class="btn-role"
+                      :class="{ active: currentPreset === 'o-s' }"
+                      @click.prevent="presetRoles('o-s')">
+                <img :src="roleBtn1" />
+                <span class="role-text">Object</span>
+              </button>
+            </div>
+          </div>
+        </form>
       </div>
 
       <div
@@ -97,8 +103,14 @@
       <!-- filled constraint (non-agent only) -->
       <template v-else>
         <template v-if="pair.c.class === 'HasType'">
-          <b>Relation type:</b>
-          <type-select v-model="pair.c.constraint"></type-select>
+          <div class="container pl-0">
+            <form>
+              <div class="form-row">
+                <span>Relation type:</span>
+                <type-select v-model="pair.c.constraint"></type-select>
+              </div>
+            </form>
+          </div>
         </template>
 
         <template v-else-if="pair.c.class === 'FromMeshIds'">
@@ -264,14 +276,14 @@
           alert('Please enter at least one constraint.');
           return;
         }
-        
+
         // Validate MeSH IDs if MeshSelect has input
         const meshValidationError = this.validateMeshIds();
         if (meshValidationError) {
           alert(meshValidationError);
           return;
         }
-        
+
         this.lastSearchOk = false;
         this.shareUrl = "";
         this.next_offset = 0;
@@ -463,26 +475,26 @@
 
         return false;
       },
-      
+
       validateMeshIds() {
         // Find all FromMeshIds constraints
         const meshConstraints = Object.values(this.constraints).filter(
           c => c && c.class === 'FromMeshIds' && c.constraint
         );
-        
+
         for (const constraint of meshConstraints) {
           const meshIds = constraint.constraint.mesh_ids || [];
-          
+
           // If mesh_ids array is empty, no validation needed (empty input is allowed)
           if (meshIds.length === 0) {
             continue;
           }
-          
+
           // Validate each mesh_id
           // MeSH ID pattern: starts with a letter (typically D, C, etc.) followed by digits
           // Example: D0135456, D000086382
           const meshIdPattern = /^[A-Z]\d+$/i;
-          
+
           for (const meshId of meshIds) {
             const meshIdStr = String(meshId).trim();
             // If there's a value, it must match the MeSH ID pattern
@@ -491,7 +503,7 @@
             }
           }
         }
-        
+
         return null; // No validation errors
       },
       presetRoles(mode) {
@@ -901,6 +913,19 @@
       margin-left: 6px;
       vertical-align: middle;
       margin-bottom: 2px;
+  }
+
+  .form-row {
+    margin-bottom: 15px;
+    border-style: solid;
+    border-color: rgba(209, 209, 209, 1);
+    border-image: none;
+    border-width: 2px;
+    border-radius: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 5px;
   }
 
 </style>


### PR DESCRIPTION
This PR adds faint, grey borders between all search options in the `RelationSearch` component to make it more clear what the distinct search options are. Currently deployed on [db.indra.bio/dev](https://db.indra.bio/dev). See also attached image.
<img width="1210" height="890" alt="image" src="https://github.com/user-attachments/assets/05a2a864-41de-47d7-85bf-862c484eb4b5" />